### PR TITLE
feat: add close() function

### DIFF
--- a/src/ivio/bam/reader.cpp
+++ b/src/ivio/bam/reader.cpp
@@ -136,6 +136,10 @@ auto reader::next() -> std::optional<record_view> {
     return pimpl_->next();
 }
 
+void reader::close() {
+    pimpl_.reset();
+}
+
 static_assert(record_reader_c<reader>);
 
 }

--- a/src/ivio/bam/reader.h
+++ b/src/ivio/bam/reader.h
@@ -31,8 +31,8 @@ public:
     ~reader();
 
     auto header() const -> bam::header const& { return header_; }
-
     auto next() -> std::optional<record_view>;
+    void close();
 };
 
 }

--- a/src/ivio/bcf/reader.cpp
+++ b/src/ivio/bcf/reader.cpp
@@ -329,6 +329,10 @@ auto reader::next() -> std::optional<record_view> {
     return pimpl_->next();
 }
 
+void reader::close() {
+    pimpl_.reset();
+}
+
 static_assert(record_reader_c<reader>);
 
 }

--- a/src/ivio/bcf/reader.h
+++ b/src/ivio/bcf/reader.h
@@ -32,8 +32,8 @@ public:
     ~reader();
 
     auto header() const -> bcf::header const& { return header_; }
-
     auto next() -> std::optional<record_view>;
+    void close();
 };
 
 }

--- a/src/ivio/bcf/writer.cpp
+++ b/src/ivio/bcf/writer.cpp
@@ -206,4 +206,10 @@ void writer::write(record_view r) {
     }, pimpl_->writer);
 }
 
+void writer::close() {
+    pimpl_.reset();
+}
+
+static_assert(record_writer_c<writer>);
+
 }

--- a/src/ivio/bcf/writer.h
+++ b/src/ivio/bcf/writer.h
@@ -27,6 +27,7 @@ struct writer : writer_base<writer> {
 
 //    void writeHeader(std::string_view v);
     void write(record_view record);
+    void close();
 };
 
 }

--- a/src/ivio/concepts.h
+++ b/src/ivio/concepts.h
@@ -40,6 +40,7 @@ concept BufferedReadable = requires(T t) {
 template <typename T>
 concept record_reader_c = requires(T t) {
     { t.next() };
+    { t.close() };
 };
 
 
@@ -47,6 +48,12 @@ template <typename T>
 concept writer_c = requires(T t) {
     { t.write(std::declval<std::span<char>>(), true) };
 //    { t.write(std::declval<char const*>()) };
+};
+
+template <typename T>
+concept record_writer_c = requires(T t) {
+    { t.write({}) };
+    { t.close() };
 };
 
 }

--- a/src/ivio/fasta/reader.cpp
+++ b/src/ivio/fasta/reader.cpp
@@ -86,6 +86,10 @@ auto reader::next() -> std::optional<record_view> {
     };
 }
 
+void reader::close() {
+    pimpl_.reset();
+}
+
 static_assert(record_reader_c<reader>);
 
 }

--- a/src/ivio/fasta/reader.h
+++ b/src/ivio/fasta/reader.h
@@ -27,6 +27,7 @@ public:
     ~reader();
 
     auto next() -> std::optional<record_view>;
+    void close();
 };
 
 }

--- a/src/ivio/fasta/writer.cpp
+++ b/src/ivio/fasta/writer.cpp
@@ -83,4 +83,10 @@ void writer::write(record_view record) {
     }, pimpl_->writer);
 }
 
+void writer::close() {
+    pimpl_.reset();
+}
+
+static_assert(record_writer_c<writer>);
+
 }

--- a/src/ivio/fasta/writer.h
+++ b/src/ivio/fasta/writer.h
@@ -23,7 +23,9 @@ struct writer : writer_base<writer> {
 
     writer(config config);
     ~writer();
+
     void write(record_view record);
+    void close();
 };
 
 }

--- a/src/ivio/fastq/reader.cpp
+++ b/src/ivio/fastq/reader.cpp
@@ -85,6 +85,10 @@ auto reader::next() -> std::optional<record_view> {
     };
 }
 
+void reader::close() {
+    pimpl_.reset();
+}
+
 static_assert(record_reader_c<reader>);
 
 }

--- a/src/ivio/fastq/reader.h
+++ b/src/ivio/fastq/reader.h
@@ -27,6 +27,7 @@ public:
     ~reader();
 
     auto next() -> std::optional<record_view>;
+    void close();
 };
 
 }

--- a/src/ivio/sam/reader.cpp
+++ b/src/ivio/sam/reader.cpp
@@ -122,6 +122,10 @@ auto reader::next() -> std::optional<record_view> {
                       };
 }
 
+void reader::close() {
+    pimpl_.reset();
+}
+
 static_assert(record_reader_c<reader>);
 
 }

--- a/src/ivio/sam/reader.h
+++ b/src/ivio/sam/reader.h
@@ -26,8 +26,8 @@ public:
 
     bool readHeaderLine();
     void readHeader();
-
     auto next() -> std::optional<record_view>;
+    void close();
 };
 
 }

--- a/src/ivio/vcf/reader.cpp
+++ b/src/ivio/vcf/reader.cpp
@@ -153,6 +153,10 @@ auto reader::next() -> std::optional<record_view> {
     };
 }
 
+void reader::close() {
+    pimpl_.reset();
+}
+
 static_assert(record_reader_c<reader>);
 
 }

--- a/src/ivio/vcf/reader.h
+++ b/src/ivio/vcf/reader.h
@@ -31,8 +31,8 @@ public:
     ~reader();
 
     auto header() const -> vcf::header const& { return header_; }
-
     auto next() -> std::optional<record_view>;
+    void close();
 };
 
 }

--- a/src/ivio/vcf/writer.cpp
+++ b/src/ivio/vcf/writer.cpp
@@ -120,4 +120,11 @@ void writer::write(record_view record) {
     }, pimpl_->writer);
 }
 
+void writer::close() {
+    pimpl_.reset();
+}
+
+static_assert(record_writer_c<writer>);
+
+
 }

--- a/src/ivio/vcf/writer.h
+++ b/src/ivio/vcf/writer.h
@@ -26,6 +26,7 @@ struct writer : writer_base<writer> {
     ~writer();
 
     void write(record_view record);
+    void close();
 };
 
 }


### PR DESCRIPTION
close() functions are quiet important, otherwise we have to add IIL (immediate invoked lambdas) or scopes every place we need a file to close earlier than its surrounding scope.